### PR TITLE
ChatContext, scroll logic and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "react-scripts": "3.4.1",
+        "react-scrollbars-custom": "^4.0.25",
         "react-use-websocket": "^2.0.1"
     },
     "scripts": {

--- a/src/assets/styles/core/_layout.scss
+++ b/src/assets/styles/core/_layout.scss
@@ -32,6 +32,9 @@
     width: 100%;
     height: 48px;
     align-items: center;
+    position: fixed;
+    top: 0;
+    z-index: 1;
 
     .logo {
         font-size: 20px;

--- a/src/assets/styles/core/_typography.scss
+++ b/src/assets/styles/core/_typography.scss
@@ -2,6 +2,16 @@ a {
     text-decoration: none;
 }
 
+.title {
+    font-family: 'Circular';
+    font-size: 24px;
+}
+
+.sub-title {
+    font-family: 'Circular';
+    font-style: 16px;
+}
+
 .logo {
     cursor: pointer;
     font-family: 'Circular';

--- a/src/assets/styles/elements/_form.scss
+++ b/src/assets/styles/elements/_form.scss
@@ -8,6 +8,7 @@
     align-items: center;
     padding: 0 12px;
     border-radius: 5px;
+    box-shadow: none;
 
     .input-base {
         padding: 6px 12px;

--- a/src/components/forms/AuthForm.jsx
+++ b/src/components/forms/AuthForm.jsx
@@ -18,6 +18,7 @@ export default ({ onChange, onSubmit, onFocus, onBlur }) => (
         >
             <Grid className="grid-item" item xs={12}>
                 <Input
+                    className="elevation"
                     onFocus={onFocus}
                     onBlur={onBlur}
                     type="email"
@@ -28,6 +29,7 @@ export default ({ onChange, onSubmit, onFocus, onBlur }) => (
             </Grid>
             <Grid className="grid-item" item xs={12}>
                 <Input
+                    className="elevation"
                     onFocus={onFocus}
                     onBlur={onBlur}
                     type="password"

--- a/src/components/forms/Input.jsx
+++ b/src/components/forms/Input.jsx
@@ -3,7 +3,7 @@ import InputBase from '@material-ui/core/InputBase';
 import Paper from '@material-ui/core/Paper';
 
 export default ({ leftIcon, rightIcon, className, value, ...props }) => (
-    <Paper className={`elevation input ${className}`}>
+    <Paper className={`input ${className}`}>
         {leftIcon && leftIcon}
         <InputBase {...props} value={value} className="input-base" fullWidth />
         {rightIcon && rightIcon}

--- a/src/components/layouts/Chat.jsx
+++ b/src/components/layouts/Chat.jsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import React, { useState, forwardRef } from 'react';
+import CustomScrollbar from 'react-scrollbars-custom';
 
 import CircularProgress from '@material-ui/core/CircularProgress';
 
@@ -10,93 +11,99 @@ import { Send, AttachFile } from '@material-ui/icons';
 import './Chat.scss';
 
 export default forwardRef(
-    (
-        {
-            data,
-            messages,
-            value,
-            onChange,
-            onSubmit,
-            onLeave,
-            onScroll,
-            loading,
-        },
-        ref,
-    ) => (
-        <div className={`chat-wrapper elevation${loading ? ' loading' : ''}`}>
-            <div className="chat-header"></div>
+    ({ data, messages, onSubmit, onLeave, status }, ref) => {
+        const [message, setMessage] = useState('');
 
-            <div className="chat-body" onScroll={onScroll} ref={ref}>
-                {loading ? (
-                    <div className="searching-users">
-                        <h1>Searching for random new friends!</h1>
-                        <CircularProgress color="inherit" />
+        const statusComponent = {
+            loading: (
+                <div className="chat-off">
+                    <h1 className="title">Searching for random new friends!</h1>
+                    <CircularProgress
+                        className="circular-loader"
+                        color="inherit"
+                    />
+                </div>
+            ),
+            on: (
+                <>
+                    <div className="presentation">
+                        You are now talking with a stranger!
                     </div>
-                ) : (
-                    <>
-                        <div className="presentation">
-                            You are now talking with a stranger!
-                        </div>
-                        {messages.map(
-                            ({ content, user: { id, isCurrentUser } }, i) => {
-                                return (
-                                    <div
-                                        key={i}
-                                        className={`message ${
-                                            isCurrentUser ? ' is-user' : ''
-                                        }${
-                                            id !== messages[i - 1]?.user.id
-                                                ? ' first'
-                                                : ''
-                                        }`}
-                                    >
-                                        <div className="content">{content}</div>
-                                    </div>
-                                );
-                            },
-                        )}
-                        <p id="dummy"></p>
-                    </>
-                )}
-            </div>
+                    {messages.map(
+                        ({ content, user: { id, isCurrentUser } }, i) => (
+                            <div
+                                key={i}
+                                className={`message ${
+                                    isCurrentUser ? ' is-user' : ''
+                                }${
+                                    id !== messages[i - 1]?.user.id
+                                        ? ' first'
+                                        : ''
+                                }`}
+                            >
+                                <div className="content">{content}</div>
+                            </div>
+                        ),
+                    )}
+                    <span id="dummy" />
+                </>
+            ),
+            off: (
+                <div className="chat-off">
+                    <h1 className="title">The chat ended :(</h1>
+                    <p className="sub-title">But don't give up yet!</p>
+                    <Button label="Let's try again?" />
+                </div>
+            ),
+        };
 
-            <div className="chat-footer">
-                <form onChange={onChange} onSubmit={onSubmit}>
-                    <Button
+        return (
+            <div ref={ref} className={`chat-wrapper elevation ${status}`}>
+                <div className="chat-header"></div>
+
+                <div className="chat-body">
+                    <CustomScrollbar disableTrackYWidthCompensation noScrollX>
+                        {statusComponent[status]}
+                    </CustomScrollbar>
+                </div>
+
+                <div className="chat-footer">
+                    <form
                         className="elevation"
-                        id="exit"
-                        disabled={loading}
-                        onClick={onLeave}
-                        label="ESC"
-                    />
-
-                    <Input
-                        className="chat-input"
-                        type="text"
-                        value={value}
-                        spellCheck={false}
-                        placeholder="Type awesome things..."
-                        rightIcon={
-                            <Button
-                                className="light"
-                                id="attach"
-                                disabled={loading}
-                                elevation={false}
-                                circular
-                                label={<AttachFile />}
-                            />
-                        }
-                    />
-
-                    <Button
-                        className="elevation"
-                        type="submit"
-                        id="send"
-                        disabled={loading}
-                        label={<Send fill="#ffffff" />}
-                    />
-                </form>
+                        onChange={({ target: { value } }) => setMessage(value)}
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            // Clear the text input
+                            if (message.length) {
+                                onSubmit(message);
+                                setMessage('');
+                            }
+                        }}
+                    >
+                        <Input
+                            className="chat-input"
+                            type="text"
+                            value={message}
+                            spellCheck={false}
+                            placeholder="Type awesome things..."
+                            rightIcon={
+                                <Button
+                                    id="attach"
+                                    className="light"
+                                    elevation={false}
+                                    label={<AttachFile />}
+                                    circular
+                                />
+                            }
+                        />
+                        <Button
+                            id="send"
+                            type="submit"
+                            label={<Send fill="#ffffff" />}
+                        />
+                    </form>
+                </div>
             </div>
-        </div>
-    ),
+        );
+    },
 );

--- a/src/components/layouts/Chat.jsx
+++ b/src/components/layouts/Chat.jsx
@@ -10,14 +10,23 @@ import { Send, AttachFile } from '@material-ui/icons';
 import './Chat.scss';
 
 export default forwardRef(
-    ({ data, messages, value, onChange, onSubmit, onLeave, loading }, ref) => (
-        <div
-            ref={ref}
-            className={`chat-wrapper elevation${loading ? ' loading' : ''}`}
-        >
+    (
+        {
+            data,
+            messages,
+            value,
+            onChange,
+            onSubmit,
+            onLeave,
+            onScroll,
+            loading,
+        },
+        ref,
+    ) => (
+        <div className={`chat-wrapper elevation${loading ? ' loading' : ''}`}>
             <div className="chat-header"></div>
 
-            <div className="chat-body">
+            <div className="chat-body" onScroll={onScroll} ref={ref}>
                 {loading ? (
                     <div className="searching-users">
                         <h1>Searching for random new friends!</h1>
@@ -46,6 +55,7 @@ export default forwardRef(
                                 );
                             },
                         )}
+                        <p id="dummy"></p>
                     </>
                 )}
             </div>

--- a/src/components/layouts/Chat.jsx
+++ b/src/components/layouts/Chat.jsx
@@ -45,7 +45,6 @@ export default forwardRef(
                             </div>
                         ),
                     )}
-                    <span id="dummy" />
                 </>
             ),
             off: (
@@ -64,6 +63,7 @@ export default forwardRef(
                 <div className="chat-body">
                     <CustomScrollbar disableTrackYWidthCompensation noScrollX>
                         {statusComponent[status]}
+                        <span id="dummy" />
                     </CustomScrollbar>
                 </div>
 

--- a/src/components/layouts/Chat.scss
+++ b/src/components/layouts/Chat.scss
@@ -41,7 +41,7 @@
     .chat-body {
         display: flex;
         flex-direction: column;
-        max-height: 540px;
+        max-height: 740px;
         overflow-y: visible;
         overflow-y: auto;
         padding: 24px;

--- a/src/components/layouts/Chat.scss
+++ b/src/components/layouts/Chat.scss
@@ -7,29 +7,29 @@
     border-radius: 5px;
     background-color: #fafafa;
 
-    &.loading {
+    .circular-loader {
+        margin: 12px;
+    }
+
+    &.loading,
+    &.off {
         .chat-header,
         .chat-footer {
             pointer-events: none;
             opacity: 0.7;
         }
 
-        .searching-users {
+        .chat-off {
             opacity: 1;
         }
     }
 
-    .searching-users {
+    .chat-off {
         font-family: 'Circular';
-        font-size: 10px;
         margin: auto;
         text-align: center;
         opacity: 0;
         transition: opacity 0.25s ease;
-
-        h1 {
-            padding: 12px;
-        }
     }
 
     .chat-header {
@@ -39,18 +39,13 @@
     }
 
     .chat-body {
-        display: flex;
-        flex-direction: column;
-        max-height: 740px;
-        overflow-y: visible;
-        overflow-y: auto;
-        padding: 24px;
         height: 100%;
+        padding: 0 12px 0;
 
         .presentation {
             text-align: center;
             font-family: 'Circular';
-            margin: 0 0 12px;
+            margin: 0 0 24px;
         }
 
         .message {
@@ -87,7 +82,7 @@
 
                 &.is-user::after {
                     left: auto;
-                    right: -7px;
+                    right: -5px;
                     border-top: 0px solid transparent;
                     border-bottom: 30px solid transparent;
                     border-left: 15px solid #303030;
@@ -95,7 +90,7 @@
                 }
 
                 &::after {
-                    left: -7px;
+                    left: -5px;
                     right: auto;
                     border-top: 0px solid transparent;
                     border-bottom: 30px solid transparent;
@@ -104,6 +99,17 @@
                 }
             }
         }
+
+        #dummy {
+            padding-top: 12px;
+        }
+
+        // Custom scrollbars style
+        .ScrollbarsCustom-Content {
+            display: flex;
+            flex-direction: column;
+            padding: 24px 24px 6px !important;
+        }
     }
 
     .chat-footer {
@@ -111,18 +117,20 @@
         height: auto;
         justify-content: space-between;
         border-radius: 0 0 5px 5px;
-        padding: 12px;
+        padding: 0 12px 12px;
         transition: opacity 0.25s ease;
 
         form {
             display: flex;
             width: 100%;
+            border-radius: 5px;
         }
 
         .chat-input {
             padding: 0 3px !important;
             width: 100% !important;
-            border-radius: 0 !important;
+            // border-radius: 0 !important;
+            border-radius: 5px 0 0 5px !important;
         }
 
         .button {

--- a/src/config/contexts/ChatContext.jsx
+++ b/src/config/contexts/ChatContext.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, createContext, useState, useContext } from 'react';
+
+import { WebSocketContext } from './WebSocketContext';
+
+export const ChatContext = createContext();
+
+export default ({ children }) => {
+    const { send, data } = useContext(WebSocketContext);
+
+    const [chatData, setChatData] = useState({});
+    const [status, setStatus] = useState('loading');
+
+    useEffect(() => {
+        console.log('chatData:', chatData);
+    }, [chatData]);
+
+    useEffect(() => {
+        console.log('status:', status);
+    }, [status]);
+
+    const providerValue = {
+        chatData,
+        setChatData,
+        status,
+        setStatus,
+        // create an abstraction over the WebSocketContext
+        send,
+        data,
+    };
+
+    return (
+        <ChatContext.Provider value={providerValue}>
+            {children}
+        </ChatContext.Provider>
+    );
+};

--- a/src/config/contexts/ChatContext.jsx
+++ b/src/config/contexts/ChatContext.jsx
@@ -5,26 +5,62 @@ import { WebSocketContext } from './WebSocketContext';
 export const ChatContext = createContext();
 
 export default ({ children }) => {
-    const { send, data } = useContext(WebSocketContext);
+    const { send, data: wsData } = useContext(WebSocketContext);
 
-    const [chatData, setChatData] = useState({});
+    // Intermediate WebSocket data
+    const [data, setData] = useState(null);
+
+    const [chat, setChat] = useState({});
     const [status, setStatus] = useState('loading');
 
     useEffect(() => {
-        console.log('chatData:', chatData);
-    }, [chatData]);
-
-    useEffect(() => {
-        console.log('status:', status);
-    }, [status]);
+        setData(wsData);
+    }, [wsData]);
 
     const providerValue = {
-        chatData,
-        setChatData,
+        chat,
+        setChat,
         status,
         setStatus,
-        // create an abstraction over the WebSocketContext
-        send,
+        actions: {
+            joinWaitingList: () => {
+                console.log('opa');
+                send({ action: 'join-waiting-list' });
+            },
+
+            leaveChat: () => {
+                send({
+                    action: 'left-chat',
+                    data: {
+                        room: chat.room,
+                    },
+                });
+                setChat({});
+            },
+
+            joinChat: (room) =>
+                send({
+                    action: 'join-chat',
+                    data: {
+                        room,
+                    },
+                }),
+
+            sendMessage: (content) =>
+                send({
+                    action: 'chat-message',
+                    data: {
+                        room: chat.room,
+                        content,
+                    },
+                }),
+
+            reset: () => {
+                providerValue.actions.leaveChat();
+                setStatus('loading');
+                setData(null);
+            },
+        },
         data,
     };
 

--- a/src/layouts/DashboardLayout.jsx
+++ b/src/layouts/DashboardLayout.jsx
@@ -5,6 +5,7 @@ import Container from '@material-ui/core/Container';
 import useWebSocket from 'react-use-websocket';
 
 import WebSocketProvider from '../config/contexts/WebSocketContext';
+import ChatProvider from '../config/contexts/ChatContext';
 
 import { Header, Friends } from '../components';
 import Menu from '../components/layouts/Menu';
@@ -22,21 +23,27 @@ export default () => {
 
     return (
         <WebSocketProvider connection={ws}>
-            <div className="layout dashboard">
-                <Header />
+            <ChatProvider>
+                <div className="layout dashboard">
+                    <Header />
 
-                <div className="dashboard-wrapper">
-                    <Container className="dashboard-container">
-                        <Menu />
-                        <Switch>
-                            <Route exact path="/" component={FeedView} />
-                            <Route exact path="/chat" component={ChatView} />
-                        </Switch>
+                    <div className="dashboard-wrapper">
+                        <Container className="dashboard-container">
+                            <Menu />
+                            <Switch>
+                                <Route exact path="/" component={FeedView} />
+                                <Route
+                                    exact
+                                    path="/chat"
+                                    component={ChatView}
+                                />
+                            </Switch>
 
-                        <Friends />
-                    </Container>
+                            <Friends />
+                        </Container>
+                    </div>
                 </div>
-            </div>
+            </ChatProvider>
         </WebSocketProvider>
     );
 };

--- a/src/layouts/DashboardLayout.scss
+++ b/src/layouts/DashboardLayout.scss
@@ -8,6 +8,11 @@
         height: 100%;
     }
 
+    .dashboard-wrapper {
+        position: absolute;
+        padding-top: 48px;
+    }
+
     .menu,
     .friends-nav {
         background-color: #505050;

--- a/src/views/ChatView.jsx
+++ b/src/views/ChatView.jsx
@@ -19,6 +19,7 @@ export default () => {
     const { currentUser } = useContext(AuthContext);
 
     const chatDataRef = useRef(chat);
+    const chatRef = useRef(null);
 
     useEffect(() => {
         chatDataRef.current = chat;
@@ -68,6 +69,18 @@ export default () => {
                         content,
                     },
                 ]);
+
+                // const {
+                //     current: { scrollHeight, clientHeight },
+                // } = chatRef;
+
+                // chatRef.current.scrollTo({
+                //     top: scrollHeight + clientHeight,
+                //     left: 0,
+                //     behavior: 'smooth',
+                // });
+
+                chatRef.current.querySelector('#dummy').scrollIntoView();
             }
 
             if (action === 'join-chat') {
@@ -100,6 +113,8 @@ export default () => {
         console.log('Leaving...');
     };
 
+    const handleScroll = () => {};
+
     return (
         <div className="view chat">
             <Chat
@@ -109,7 +124,9 @@ export default () => {
                 onChange={({ target: { value } }) => setMessage(value)}
                 onSubmit={handleSendMessage}
                 onLeave={handleLeave}
+                onScroll={handleScroll}
                 loading={loading}
+                ref={chatRef}
             />
         </div>
     );

--- a/src/views/ChatView.jsx
+++ b/src/views/ChatView.jsx
@@ -13,9 +13,12 @@ export default () => {
     const [messages, setMessages] = useState([]);
 
     // Contexts
-    const { chatData, setChatData, status, setStatus, send, data } = useContext(
+    const { chat, setChat, status, setStatus, actions, data } = useContext(
         ChatContext,
     );
+
+    const { joinWaitingList, leaveChat, sendMessage } = actions;
+
     const { currentUser } = useContext(AuthContext);
 
     // Refs
@@ -24,18 +27,15 @@ export default () => {
     useEffect(() => {
         document.addEventListener('keydown', handleEscape);
 
-        send({
-            action: 'join-waiting-list',
-        });
+        joinWaitingList();
 
         return () => {
             document.removeEventListener('keydown', handleEscape);
         };
-    }, [send]);
+    }, []);
 
     useEffect(() => {
         if (data) {
-            console.log(data);
             const { action } = data;
 
             if (action === 'chat-message') {
@@ -60,20 +60,18 @@ export default () => {
             }
 
             if (action === 'join-chat') {
-                setChatData(data.data);
+                setChat(data.data);
                 setStatus('on');
             }
 
             if (action === 'left-chat') {
-                send({
-                    action: 'left-chat',
-                    data: { room: chatData?.room },
-                });
+                leaveChat();
                 setStatus('off');
             }
 
             if (action === 'disconnect') {
-                setStatus('disconnected');
+                leaveChat();
+                setStatus('off');
             }
         }
     }, [data, currentUser]);
@@ -84,16 +82,6 @@ export default () => {
             chatRef.current.querySelector('#dummy').scrollIntoView();
     }, [messages]);
 
-    // Send a new message
-    const handleSendMessage = (content) =>
-        send({
-            action: 'chat-message',
-            data: {
-                room: chatData.room,
-                content,
-            },
-        });
-
     const handleEscape = ({ keyCode }) => {
         // console.log(keyCode);
     };
@@ -101,9 +89,9 @@ export default () => {
     return (
         <div className="view chat">
             <Chat
-                data={chatData}
+                data={chat}
                 messages={messages}
-                onSubmit={handleSendMessage}
+                onSubmit={(message) => sendMessage(message)}
                 // onLeave={handleLeave}
                 status={status}
                 ref={chatRef}

--- a/src/views/FeedView.jsx
+++ b/src/views/FeedView.jsx
@@ -1,11 +1,33 @@
-import React from 'react';
+import React, { useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
+
+import { ChatContext } from '../config/contexts/ChatContext';
 
 import { Button } from '../components';
 
 import './FeedView.scss';
 
 export default () => {
+    const { chatData, setChatData, status, send } = useContext(ChatContext);
+
+    useEffect(() => {
+        console.log(chatData);
+
+        // Leave any chat that may be open
+        // This is due to react-router state persistence
+        chatData &&
+            send({
+                action: 'left-chat',
+                data: { room: chatData.room },
+            });
+
+        setChatData({});
+    }, []);
+
+    useEffect(() => {
+        console.log(status);
+    }, [status]);
+
     return (
         <section className="view feed">
             <div className="feed-posts">

--- a/src/views/FeedView.jsx
+++ b/src/views/FeedView.jsx
@@ -8,25 +8,15 @@ import { Button } from '../components';
 import './FeedView.scss';
 
 export default () => {
-    const { chatData, setChatData, status, send } = useContext(ChatContext);
+    const {
+        actions: { reset },
+    } = useContext(ChatContext);
 
     useEffect(() => {
-        console.log(chatData);
-
-        // Leave any chat that may be open
+        // Reset the chat data
         // This is due to react-router state persistence
-        chatData &&
-            send({
-                action: 'left-chat',
-                data: { room: chatData.room },
-            });
-
-        setChatData({});
+        reset();
     }, []);
-
-    useEffect(() => {
-        console.log(status);
-    }, [status]);
 
     return (
         <section className="view feed">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,6 +3054,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 clean-css@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
@@ -3133,6 +3138,11 @@ clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
+cnbuilder@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/cnbuilder/-/cnbuilder-2.5.0.tgz#50f55932f672c413515d9d5bb21d4b7a7a60b07b"
+  integrity sha512-Ddxm+RpEs/atVU7Kgbt1qgLHaJHdHBpIiP+lAKgdF16YJtDcIXTKUuTrk47DgJ4D8OpUe/mKvKD0R+kfxcJQ4w==
 
 co@^4.6.0:
   version "4.6.0"
@@ -9075,7 +9085,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9301,6 +9311,14 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-draggable@^4.4.2:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
+  integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react-error-overlay@^6.0.7:
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
@@ -9399,6 +9417,15 @@ react-scripts@3.4.1:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.1.2"
+
+react-scrollbars-custom@^4.0.25:
+  version "4.0.25"
+  resolved "https://registry.yarnpkg.com/react-scrollbars-custom/-/react-scrollbars-custom-4.0.25.tgz#64c1390fc04fe2b90373d5d142bd129a3d46e394"
+  integrity sha512-kipJK49fwvHsDgumIGiTmrJkxw5QD9urN7f4o2VvSrsHNOWMrDppNf+IjgobT5w+ZjbaaHfLk5NmZ/n1zgKtcw==
+  dependencies:
+    cnbuilder "^2.5.0"
+    react-draggable "^4.4.2"
+    zoom-level "^2.5.0"
 
 react-transition-group@^4.4.0:
   version "4.4.1"
@@ -11824,3 +11851,8 @@ yargs@^13.3.0, yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+zoom-level@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/zoom-level/-/zoom-level-2.5.0.tgz#286ec16f247b8bb7a900df6612567688eeef498a"
+  integrity sha512-7UlRWU4Q3uCMCeDVMOm7eBrIu145OqsIJ3p6zq58l8UsSYwKWxc6zEapC5YA9tIeh0oheb4cT9Kk2Wq353loFg==


### PR DESCRIPTION
## Description

### Scroll to bottom

Created a basic scroll logic to detect new messages and scroll the messages container to the bottom (if necessary).

> **Note:** It would be nice to add some smooth animation when scroll. For now, it's just jumping to the bottom.

### ChatContext and the state persistence in the route

I recreated the ChatContext component because it's the key to the state persistence in route changes and it helped to fix the duplicating messages bug.

The duplicating messages bug was happening because the state of the WebSocket data wasn't changing, which means that if the last action you did in the chat was **chat-message**, the data would persist even changing the route, so when you leave and enter the ChatView again, it would load the old data containing that  **chat-message** data.

### The solution

I've created a method in the ChatContext to reset the data when the user goes to the FeedView.

> **Note:** We should find a way to call this method in any view that isn't the ChatView.

## Related issues

#6 
#8 